### PR TITLE
Separate out Argument Parsing so that all files can access args

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
 ]
 
 [tool.flit.scripts]
-pytui = "pytui.main:main"
+pytui = "pytui.__main__:main"
 
 [tool.coverage.run]
 source = ["src"]

--- a/pytui/__main__.py
+++ b/pytui/__main__.py
@@ -1,24 +1,14 @@
-import sys
-
+from pytui.arguments import args, parse_arguments
 from pytui.core import get_all_error_results
 from pytui.display import Display
 
 
 def main() -> None:
     """Run the application"""
-    no_display = False
+    parse_arguments()
 
-    if len(sys.argv) > 1 and sys.argv[1] == '-n':
-        no_display = True
-        sys.argv.pop(1)
-
-    if len(sys.argv) == 1:
-        print("Usage: pytui [-n] <script>")
-        sys.exit(1)
-
-    if no_display:
-        results = get_all_error_results()
-        print(results)
+    if args['no_display']:
+        print(get_all_error_results())
 
     else:
         Display().run()

--- a/pytui/__main__.py
+++ b/pytui/__main__.py
@@ -1,15 +1,27 @@
 import sys
 
+from pytui.core import get_all_error_results
 from pytui.display import Display
 
 
 def main() -> None:
     """Run the application"""
+    no_display = False
+
+    if len(sys.argv) > 1 and sys.argv[1] == '-n':
+        no_display = True
+        sys.argv.pop(1)
+
     if len(sys.argv) == 1:
-        print("Usage: pytui <script>")
+        print("Usage: pytui [-n] <script>")
         sys.exit(1)
 
-    Display().run()
+    if no_display:
+        results = get_all_error_results()
+        print(results)
+
+    else:
+        Display().run()
 
 
 if __name__ == "__main__":

--- a/pytui/__main__.py
+++ b/pytui/__main__.py
@@ -1,8 +1,14 @@
+import sys
+
 from pytui.display import Display
 
 
 def main() -> None:
     """Run the application"""
+    if len(sys.argv) == 1:
+        print("Usage: pytui <script>")
+        sys.exit(1)
+
     Display().run()
 
 

--- a/pytui/arguments.py
+++ b/pytui/arguments.py
@@ -1,0 +1,25 @@
+import argparse
+import sys
+from collections import defaultdict
+
+args = defaultdict(lambda: None)
+
+
+def parse_arguments() -> None:
+    """Parse arguments and store them in pytui.arguments.args"""
+    parser = argparse.ArgumentParser(sys.argv[0])
+    parser.add_argument("-n", "--no-display",
+                        action='store_true',
+                        default=False,
+                        help="Run without display")
+    parser.add_argument("-c", "--copy-error",
+                        action='store_true',
+                        default=False,
+                        help="Copy error to clipboard")
+    parser.add_argument("script", help="Python script to run")
+
+    # Keep the remaining arguments in `sys.argv`
+    parsed, sys.argv[1:] = parser.parse_known_args()
+
+    global args
+    args.update(vars(parsed))

--- a/pytui/core.py
+++ b/pytui/core.py
@@ -1,0 +1,40 @@
+import subprocess  # noqa: S404
+import sys
+
+from pytui.backends.stackoverflow import StackOverflowFinder
+from pytui.parser import parse_error
+
+
+def run_and_get_stderr(script_name: str) -> str:
+    """Run the python script and return the stderr output"""
+    # TODO: Perhaps add a way to also pass in extra arguments
+    args = ["python", script_name]
+    process = subprocess.run(args, stderr=subprocess.PIPE, shell=False)  # noqa: S603
+
+    if not process.stderr:
+        return None
+
+    return process.stderr.decode('utf-8')
+
+
+def get_all_error_results(max_results: int = 10) -> dict:
+    """
+    This is the core function that runs the script and returns error results
+
+    The script name is read from `sys.argv`, and the stderr output of the
+    program is parsed for the error. This error is then passed to the
+    StackOverflow backend and all the results are returned.
+    """
+    all_text = run_and_get_stderr(sys.argv[1])
+    error, packages = parse_error(all_text)
+
+    stack_overflow = StackOverflowFinder()
+    error_answers = stack_overflow.search(error, max_results)  # noqa: F841
+
+    data = {
+        "error": error,
+        "packages": packages,
+        "results": error_answers
+    }
+
+    return data

--- a/pytui/core.py
+++ b/pytui/core.py
@@ -1,15 +1,15 @@
 import subprocess  # noqa: S404
-import sys
 
+from pytui.arguments import args
 from pytui.backends.stackoverflow import StackOverflowFinder
 from pytui.parser import parse_error
 
 
-def run_and_get_stderr(script_name: str) -> str:
+def run_and_get_stderr() -> str:
     """Run the python script and return the stderr output"""
     # TODO: Perhaps add a way to also pass in extra arguments
-    args = ["python", script_name]
-    process = subprocess.run(args, stderr=subprocess.PIPE, shell=False)  # noqa: S603
+    run_args = ["python", args['script']]
+    process = subprocess.run(run_args, stderr=subprocess.PIPE, shell=False)  # noqa: S603
 
     if not process.stderr:
         return None
@@ -25,7 +25,7 @@ def get_all_error_results(max_results: int = 10) -> dict:
     program is parsed for the error. This error is then passed to the
     StackOverflow backend and all the results are returned.
     """
-    all_text = run_and_get_stderr(sys.argv[1])
+    all_text = run_and_get_stderr()
     error, packages = parse_error(all_text)
 
     stack_overflow = StackOverflowFinder()

--- a/pytui/display.py
+++ b/pytui/display.py
@@ -3,8 +3,7 @@ from textual.app import App
 from textual.view import DockView
 from textual.widgets import Footer, Header, Placeholder, ScrollView
 
-from pytui.backends.stackoverflow import StackOverflowFinder
-from pytui.parse_errors import run_and_get_errors
+from pytui.core import get_all_error_results
 from pytui.settings import APP_NAME
 
 
@@ -18,17 +17,16 @@ class Display(App):
 
     async def on_startup(self, event: events.Startup) -> None:
         """App layout"""
-        self.error, self.packages = run_and_get_errors()
         view = await self.push_view(DockView())
 
-        stack_overflow = StackOverflowFinder()
-        error_answers = stack_overflow.search(self.error, 10)  # noqa: F841
+        results = get_all_error_results()
 
-        header = Header(f"{APP_NAME}: {self.error}")
+        header = Header(f"{APP_NAME}: {results['error']}")
         footer = Footer()
         sidebar = Placeholder(name="sidebar")
 
-        body = ScrollView(f"We found {len(error_answers)} answers")
+        num_answers = len(results['results'])
+        body = ScrollView(f'Found {num_answers} answers!')
 
         footer.add_key("b", "Toggle sidebar")
         footer.add_key("q", "Quit")

--- a/pytui/parser.py
+++ b/pytui/parser.py
@@ -1,12 +1,9 @@
-import subprocess  # noqa: S404
-import sys
-from typing import Tuple
-
 from parse import findall
 
 
-def parse_err(txt: str) -> tuple:
-    """Extract error message and packages involved in stack trace.
+def parse_error(txt: str) -> tuple:
+    """
+    Extract error message and packages involved in stack trace.
 
     The specific error message is assumed to be the last line that is not indented.
     """
@@ -30,14 +27,3 @@ def parse_err(txt: str) -> tuple:
         packages.add(path_elements[path_elements.index(key) + 1])
 
     return error_msg, packages
-
-
-def run_and_get_errors() -> Tuple[str, str]:
-    """Run the python script and find errors."""
-    args = sys.argv
-    args[0] = 'python'  # Replace pytui with 'python' to act as a runner
-    result = subprocess.run(args, stderr=subprocess.PIPE, shell=False)  # noqa: S603
-
-    if result.stderr:
-        error_msg, packages = parse_err(result.stderr.decode('utf-8'))
-        return error_msg, packages


### PR DESCRIPTION
Since we can't pass around arguments into the `Display` class, the arguments are now parsed at the start of the application and are stored globally in `pytui.arguments.args`.

Note: These edits have been made on the code as it is after #23 , so that should be merged first. Only the last commit (b2c0090) is new here.