### PR TITLE
Add CLI option to copy error to the clipboard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ requires=[
     "textual == 0.1.5",
     "rich == 10.5.0",
     "typer == 0.3.2",
+    "pyperclip == 1.8.2",
 ]
 
 [tool.flit.metadata.requires-extra]

--- a/pytui/core.py
+++ b/pytui/core.py
@@ -1,5 +1,7 @@
 import subprocess  # noqa: S404
 
+import pyperclip
+
 from pytui.arguments import args
 from pytui.backends.stackoverflow import StackOverflowFinder
 from pytui.parser import parse_error
@@ -27,6 +29,10 @@ def get_all_error_results(max_results: int = 10) -> dict:
     """
     all_text = run_and_get_stderr()
     error, packages = parse_error(all_text)
+
+    # Copy the error to the clipboard if asked
+    if args['copy_error']:
+        pyperclip.copy(error)
 
     stack_overflow = StackOverflowFinder()
     error_answers = stack_overflow.search(error, max_results)  # noqa: F841


### PR DESCRIPTION
Using the `-c` or `--copy-error` option on the command line will now
copy the error onto the clipboard using the `pyperclip` library

Perhaps later we can also think about how we want to copy the
packages to the clipboard as well. I don't think just adding them
onto the end naively would be helpful, since then just searching
with the clipboard results might have misleading results because
of the package names.

Solves #17 