### PR TITLE
Add a cache for outgoing HTTP Requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ requires=[
     "rich == 10.5.0",
     "typer == 0.3.2",
     "pyperclip == 1.8.2",
+    "requests-cache == 0.7.1",
 ]
 
 [tool.flit.metadata.requires-extra]

--- a/pytui/backends/__init__.py
+++ b/pytui/backends/__init__.py
@@ -1,0 +1,4 @@
+from pathlib import Path
+
+REQUEST_CACHE_LOCATION = Path.home() / Path(".pytui_cache")
+REQUEST_CACHE_DURATION = 60 * 60 * 24   # One day (in seconds)

--- a/pytui/backends/stackoverflow.py
+++ b/pytui/backends/stackoverflow.py
@@ -1,8 +1,9 @@
 from typing import List
 
-import requests
+import requests_cache
 from rich import print
 
+from pytui.backends import REQUEST_CACHE_DURATION, REQUEST_CACHE_LOCATION
 from pytui.settings import SO_FILTER
 
 
@@ -34,9 +35,13 @@ class StackOverflowFinder:
     """Get results from Stack Overflow"""
 
     def __init__(self):
-        # Initialize SE API object...
-        self.session = requests.session()
-        pass
+        backend = requests_cache.backends.FileCache(REQUEST_CACHE_LOCATION)
+
+        self.session = requests_cache.CachedSession(
+            'stackoverflow',
+            backend=backend,
+            expire_after=REQUEST_CACHE_DURATION,
+        )
 
     def search(self, error_message: str, max_results: int = 5) -> List[StackOverflowQuestion]:
         """Search Stack Overflow with the initialized SE API object"""


### PR DESCRIPTION
Using the `requests-cache` module to cache requests. Some constants
are defined in `pytui/backends/__init__.py` which specify the
default location (~/.pytui_cache) and duration (1 day) to cache
the requests.

Solves #26 