### PR TITLE
Update display to use Markdown rendering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ requires=[
     "typer == 0.3.2",
     "pyperclip == 1.8.2",
     "requests-cache == 0.7.1",
+    "html2text == 2020.1.16",
 ]
 
 [tool.flit.metadata.requires-extra]

--- a/pytui/display.py
+++ b/pytui/display.py
@@ -1,3 +1,6 @@
+import html2text
+from rich.console import RenderableType
+from rich.markdown import Markdown
 from textual import events
 from textual.app import App
 from textual.view import DockView
@@ -15,18 +18,35 @@ class Display(App):
         await self.bind("q,ctrl+c", "quit")
         await self.bind("b", "view.toggle('sidebar')")
 
+    def create_body_text(self) -> RenderableType:
+        """Return the text to display in the ScrollView"""
+        if self.data['results'] == []:
+            return "Could not find any results. Sorry!"
+
+        # For now assume first question... but ideally user should be able to pick
+        # the question from the sidebar
+        question = self.data['results'][0]
+
+        text = ""
+        for index, answer in enumerate(question.answers):
+            text += f"---\n### Answer {index}\n---\n"
+            text += html2text.html2text(answer.body)
+            text += "\n"
+
+        output = Markdown(text)
+        return output
+
     async def on_startup(self, event: events.Startup) -> None:
         """App layout"""
         view = await self.push_view(DockView())
 
-        results = get_all_error_results()
+        self.data = get_all_error_results()
 
-        header = Header(f"{APP_NAME}: {results['error']}")
+        header = Header(f"{APP_NAME}: {self.data['error']}")
         footer = Footer()
         sidebar = Placeholder(name="sidebar")
 
-        num_answers = len(results['results'])
-        body = ScrollView(f'Found {num_answers} answers!')
+        body = ScrollView(self.create_body_text())
 
         footer.add_key("b", "Toggle sidebar")
         footer.add_key("q", "Quit")


### PR DESCRIPTION
This patch takes the StackOverflow answer bodies and converts them
to markdown from HTML using the `html2text` library. Then, this
markdown is passed through the `Markdown` generator in rich which
allows us to get nicely formatted output.

For now, only the answers for the first question in the list of
results is shown. In the future, we need to:

  1. Also display the question on top
  2. Figure out how to let the user change between the different
     questions that were a part of the search result.

I've attempted to try to do (2) currently, but it seems there's
no built in list widget (where we can assign callbacks to each
button) - at least that I can see. The framework is still very
much incomplete. Chances are we may not be able to do something
much more sophisticated than what is currently being done.