### PR TITLE
Error parsing

### DIFF
--- a/pytui/core.py
+++ b/pytui/core.py
@@ -4,7 +4,7 @@ import pyperclip
 
 from pytui.arguments import args
 from pytui.backends.stackoverflow import StackOverflowFinder
-from pytui.parser import parse_stacktrace
+from pytui.parser import parse_traceback
 
 
 def run_and_get_stderr() -> str:
@@ -28,7 +28,7 @@ def get_all_error_results(max_results: int = 10) -> dict:
     StackOverflow backend and all the results are returned.
     """
     all_text = run_and_get_stderr()
-    parsed = parse_stacktrace(all_text)
+    parsed = parse_traceback(all_text)
 
     # Copy the error to the clipboard if asked
     if parsed["error_message"]:

--- a/pytui/parser.py
+++ b/pytui/parser.py
@@ -13,7 +13,7 @@ def _error_message(txt: str) -> str:
 
 
 def _error_files(txt: str) -> list[dict[str, str]]:
-    """Extract files named in stack trace."""
+    """Extract files named in traceback."""
     return [
         line.named
         for line
@@ -34,8 +34,8 @@ def _extract_packages(files: list[dict[str, str]]) -> set[str]:
     return packages
 
 
-def parse_stacktrace(txt: str) -> dict[str, Any]:
-    """Extract error message and packages involved in stack trace."""
+def parse_traceback(txt: str) -> dict[str, Any]:
+    """Extract error message and packages involved in traceback."""
     error_message = _error_message(txt)
     files = _error_files(txt)
     packages = _extract_packages(files)
@@ -44,5 +44,5 @@ def parse_stacktrace(txt: str) -> dict[str, Any]:
         'error_message': error_message,
         'files': files,
         'packages': packages,
-        'stacktrace': txt,
+        'traceback': txt,
     }

--- a/pytui/parser.py
+++ b/pytui/parser.py
@@ -44,4 +44,5 @@ def parse_stacktrace(txt: str) -> dict[str, Any]:
         'error_message': error_message,
         'files': files,
         'packages': packages,
+        'stacktrace': txt,
     }

--- a/tests/test_error_parsing.py
+++ b/tests/test_error_parsing.py
@@ -1,14 +1,14 @@
 import pytest
 import toml
 
-from pytui.parser import parse_stacktrace
+from pytui.parser import parse_traceback
 from pytui.settings import BASE_DIR
 
 TEST_DATA_DIR = BASE_DIR.parent / 'tests' / 'data'
 
 
-for_each_example_stacktrace = pytest.mark.parametrize(
-    "example_stacktrace",
+for_each_example_traceback = pytest.mark.parametrize(
+    "example_traceback",
     [
         toml.load(example)
         for example
@@ -17,32 +17,32 @@ for_each_example_stacktrace = pytest.mark.parametrize(
 )
 
 
-@for_each_example_stacktrace
-def test_parsing_has_correct_format(example_stacktrace: dict) -> None:
-    """Ensure parse_stacktrace provides dict."""
-    parsed = parse_stacktrace(example_stacktrace['traceback'])
-    assert list(parsed.keys()) == ['error_message', 'files', 'packages']  # noqa: S101
+@for_each_example_traceback
+def test_parsing_has_correct_format(example_traceback: dict) -> None:
+    """Ensure parse_traceback provides dict."""
+    parsed = parse_traceback(example_traceback['traceback'])
+    assert list(parsed.keys()) == ['error_message', 'files', 'packages', 'traceback']  # noqa: S101
 
 
-@for_each_example_stacktrace
-def test_correct_error_message(example_stacktrace: dict) -> None:
+@for_each_example_traceback
+def test_correct_error_message(example_traceback: dict) -> None:
     """Ensure that the error message is correctly capturerd."""
-    parsed = parse_stacktrace(example_stacktrace['traceback'])
-    assert parsed['error_message'] == example_stacktrace['error_message']  # noqa: S101
+    parsed = parse_traceback(example_traceback['traceback'])
+    assert parsed['error_message'] == example_traceback['error_message']  # noqa: S101
 
 
-@for_each_example_stacktrace
-def test_correct_file_references(example_stacktrace: dict) -> None:
+@for_each_example_traceback
+def test_correct_file_references(example_traceback: dict) -> None:
     """Ensure file information was extracted correctly."""
-    parsed = parse_stacktrace(example_stacktrace['traceback'])
+    parsed = parse_traceback(example_traceback['traceback'])
     for field in ['file', 'line', 'method']:
         found = [i[field] for i in parsed['files']]
-        expected = [i[field] for i in example_stacktrace['files']]
+        expected = [i[field] for i in example_traceback['files']]
         assert found == expected  # noqa: S101
 
 
-@for_each_example_stacktrace
-def test_correct_packages(example_stacktrace: dict) -> None:
+@for_each_example_traceback
+def test_correct_packages(example_traceback: dict) -> None:
     """Ensure that packages involved are correrctly identified."""
-    parsed = parse_stacktrace(example_stacktrace['traceback'])
-    assert set(parsed['packages']) == set(example_stacktrace['packages'])  # noqa: S101
+    parsed = parse_traceback(example_traceback['traceback'])
+    assert set(parsed['packages']) == set(example_traceback['packages'])  # noqa: S101


### PR DESCRIPTION
return the full traceback from parser and renamed stacktrace to traceback to be more consistent with the python nomenclature